### PR TITLE
Fix publish failure due to permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,13 @@ name: Deploy to GitHub Pages
 on:
   push:
     branches: [ master ]
-    
+
+# The git hub push was failing because of permission issues. This fixes that failure. 
+# I went through and tested each possible permission. This is the only that was required to fix the problem I was having.
+# For more on permissions: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions
+permissions:
+  contents: write
+  
 jobs:
   deploy-to-github-pages:
     # use ubuntu-latest image to run steps on


### PR DESCRIPTION
https://github.com/jquintus/WordleHelper/actions/runs/4331928933/jobs/7564080744#step:5:117

remote: Write access to repository not granted.
fatal: unable to access 'https://github.com/jquintus/WordleHelper.git/': The requested URL returned error: 403 Running post deployment cleanup jobs… 🗑️
/usr/bin/git worktree remove github-pages-deploy-action-temp-deployment-folder --force Error: The deploy step encountered an error: The process '/usr/bin/git' failed with exit code 128 ❌ Deployment failed! ❌